### PR TITLE
chore: fix command category typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
       {
         "command": "hadolint.selectExecutable",
         "title": "Select Hadolint Executable",
-        "category": "Hdolint"
+        "category": "Hadolint"
       }
     ]
   },


### PR DESCRIPTION
The command is labeled `Hdolint: Select Executable`, where hadolint is spelled incorrectly.